### PR TITLE
Removed return type in GeneratesUsernames trait

### DIFF
--- a/src/GeneratesUsernames.php
+++ b/src/GeneratesUsernames.php
@@ -40,9 +40,9 @@ trait GeneratesUsernames
      *
      * Override this method in your model to customize logic.
      *
-     * @return string
+     * @return string|null
      */
-    public function getField(): string
+    public function getField()
     {
         // Support pre-v2 getName method overrides
         if (method_exists($this, 'getName')) {


### PR DESCRIPTION
- Fixes bug in #25 due to not having a specified column, or it being null
- This case would now return the same as calling $generator->generate();