### PR TITLE
2.6.2 - Fix #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Works for Laravel versions above 5.5 including Laravel 9.
 
 ## Most Recent Update
 
-**v2.6.1**
+**v2.6.2**
 
-- Added support for PHP 8.1
-- Set minimum PHP version to 7.4
+- Fixed potential SQL injection issue when using REGEXP function.
+- Fixed issue where REGEXP function was not returning correct number of similar usernames only when using a separator.
+- Changed default config option `prefer_regexp` from `true` to `false`
 
-*Updated January 2, 2022*
+*Updated Feb 21, 2022*
 
 
 
@@ -649,6 +650,12 @@ And then in `config/username_generator.php` add the driver to the top of the dri
 MIT
 
 ## Change Log
+
+**v2.6.2**
+
+- Fixed potential SQL injection issue when using REGEXP function.
+- Fixed issue where REGEXP function was not returning correct number of similar usernames only when using a separator.
+- Changed default config option `prefer_regexp` from `true` to `false`
 
 **v2.6.1**
 

--- a/src/FindSimilarUsernames.php
+++ b/src/FindSimilarUsernames.php
@@ -72,9 +72,7 @@ trait FindSimilarUsernames
      */
     private function searchUsingRegexp(string $username)
     {
-        $column = $this->getColumn();
-
-        return static::whereRaw("$column REGEXP '{$username}([0-9]*)?$'")->get();
+        return static::where($this->getColumn(), 'REGEXP', $username.'('.$this->getSeparator().')?([0-9]*)?$')->get();
     }
 
     /**
@@ -85,5 +83,23 @@ trait FindSimilarUsernames
     private function getColumn(): string
     {
         return $this->usernameColumn ?? config('username_generator.column', 'username');
+    }
+
+    /**
+     * Get the username separator.
+     *
+     * Check if the model has a custom separator in its class before checking config.
+     *
+     * @return string
+     */
+    private function getSeparator(): string
+    {
+        if(method_exists($this, 'generatorConfig')) {
+            $generator = new Generator();
+            $this->generatorConfig($generator);
+            return $generator->getConfig('separator', '');
+        }
+
+        return config('username_generator.separator', '');
     }
 }

--- a/src/config/username_generator.php
+++ b/src/config/username_generator.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\User;
 use TaylorNetwork\UsernameGenerator\Drivers\EmailDriver;
 use TaylorNetwork\UsernameGenerator\Drivers\NameDriver;
 
@@ -54,7 +53,7 @@ return [
      *
      * This is only used if unique is true
      */
-    'model' => User::class,
+    'model' => \App\Models\User::class,
 
     /*
      * Database field to check and store username
@@ -102,9 +101,11 @@ return [
     'generate_entered_username' => true,
 
     /*
-     * Prefer using REGEXP
+     * Prefer using database REGEXP function?
+     *
+     * LIKE function will be used as a backup on failure.
      */
-    'prefer_regexp' => true,
+    'prefer_regexp' => false,
 
     /*
      * Field Map


### PR DESCRIPTION
This fixes #52 possible issue of SQL injection as well as an issue where while using the `REGEXP` database function with a separator, the `findSimilarUsernames` method would fail to get the correct number of similar usernames.

Regarding SQL injection:
As long as `validate_characters` was set to `true` and `separator` was not a space (`' '`) it would be a non-issue.
The string passed to the `whereRaw` function would be after all the validation, case changing and adding of separators, etc.
