### PR TITLE
Retry makeUnique until unique username found

### DIFF
--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -255,7 +255,14 @@ abstract class BaseDriver implements Driver, HandlesConfig
             }
 
             if (($similar = count($this->model()->findSimilarUsernames($text))) > 0) {
-                return $text.$this->getConfig('separator').$similar;
+                $username = $text.$this->getConfig('separator').$similar;
+
+                // if not unique, due to similar usernames existing in db, increment similar number by one until unique
+                while (method_exists($this->model(), 'isUsernameUnique') && !$this->model()->isUsernameUnique($username)) {
+                    $username = ++$username;
+                }
+
+                return $username;
             }
         }
 


### PR DESCRIPTION
If there are similar usernames picked up by the `findSimilarUsernames` call, it'll throw off the count and unique username generation will get stuck on a number.

For example, a set of 4 users with usernames:
user
user1
user3

`makeUnique` would generate `user3` and fail, and never get past that point.  This fixes that by trying the count, then incrementing by 1 until it's finally unique.